### PR TITLE
Add a loading indicator / error state for projects

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -39,6 +39,8 @@ export const getHeadTitle = (path: string) => {
 }
 export const isLocalhost = window.location.host.includes("localhost") || navigator.userAgent.includes("ReactSnap");
 
+export const isReactSnap = navigator.userAgent.includes("ReactSnap");
+
 export async function fetchBackend(route: string, method: ("GET" | "POST" | "PUT" | "DELETE"), requestBody?: any): Promise<Response> {
     let headers: string[][] = [["Content-Type", "application/json"]];
 

--- a/src/common/services/projects.ts
+++ b/src/common/services/projects.ts
@@ -1,5 +1,6 @@
 import { IUser } from "./users";
-import { fetchBackend, ObjectToPathQuery, match } from "../helpers";
+import { fetchBackend, ObjectToPathQuery, match, isReactSnap } from "../helpers";
+import { useState } from "react";
 
 export async function CreateProject(projectData: ICreateProjectsRequestBody): Promise<Response> {
     // Reformat microsoft store links to an international format
@@ -42,6 +43,49 @@ export async function GetAllProjects(): Promise<IProject[]> {
 
 export async function GetLaunchProjects(year: number): Promise<IProject[]> {
     return (await (await fetchBackend(`projects`, "GET")).json()).filter((project: IProject) => project.launchYear == year && project.awaitingLaunchApproval == false);
+}
+
+export interface IProjectsState {
+    projects?: IProject[]
+    error?: Error
+    isLoading: boolean
+}
+
+export function useProjects(year?: number): [IProjectsState, () => Promise<void>] {
+    const cacheKey = 'loadedProjects' + (year || '')
+    const cache: IProject[] = (window as any)[cacheKey]
+    const initialState: IProjectsState = { isLoading: false }
+
+    if (!isReactSnap && cache && cache.length) {
+        initialState.projects = cache
+    }
+    
+    const [res, setRes] = useState<IProjectsState>(initialState)
+
+    const getProjects = async () => {
+        setRes(prevState => ({ ...prevState, isLoading: true }))
+
+        let projects: IProject[]
+        try {
+            if (!year) {
+                projects = await GetAllProjects()
+            } else {
+                projects = await GetLaunchProjects(year)
+            }
+            setRes(prevState => ({ ...prevState, isLoading: false, projects }))
+
+            if (isReactSnap) {
+                var script = document.createElement("script");
+                script.type = "text/javascript";
+                script.innerHTML = `window['${cacheKey}'] = ${JSON.stringify(projects)}`;
+                document.getElementsByTagName('head')[0].appendChild(script);
+            }
+        } catch (error) {
+            setRes(prevState => ({ ...prevState, isLoading: false, error }))
+        }
+    }
+
+    return [res, getProjects]
 }
 
 interface IModifyProjectsRequestBody {

--- a/src/views/Launch.tsx
+++ b/src/views/Launch.tsx
@@ -1,24 +1,21 @@
 import React, { useState, CSSProperties } from "react";
-import { Text, Stack, PrimaryButton, IconButton, Image, ImageCoverStyle, ImageFit } from "office-ui-fabric-react";
+import { Text, Stack, FontIcon, Spinner, Image, ImageCoverStyle, ImageFit, ProgressIndicator } from "office-ui-fabric-react";
 import styled from 'styled-components';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import HoverBox from '../components/HoverBox';
 import { Images } from "../common/const";
 import { Depths } from "@uifabric/fluent-theme/lib/fluent/FluentDepths";
-import { GetLaunchProjects, IProject } from "../common/services/projects";
+import { useProjects, IProject } from "../common/services/projects";
 import { ProjectCard } from "../components/ProjectCard";
 import { GetCurrentDiscordUser, IDiscordUser } from "../common/services/discord";
 
 export const Launch = () => {
-    const [projects, setProjects] = React.useState<IProject[]>();
+    const [state, getProjects] = useProjects(2020);
     const [user, setUser] = React.useState<IDiscordUser>();
 
-    async function GetNextLaunchEventProjects() {
-        setProjects(await GetLaunchProjects(2020));
-    }
     React.useEffect(()=>{
-        GetNextLaunchEventProjects();
+        getProjects();
         (async () => {
             setUser(await GetCurrentDiscordUser());
         })();
@@ -26,23 +23,34 @@ export const Launch = () => {
 
     return (
         <Stack tokens={{childrenGap: 25}}>
-                <Stack horizontal wrap style={{ boxShadow: Depths.depth16 }} maxWidth="1200px">
-                    <Image width="100%" height="400px" src={Images.launchAppsHero} coverStyle={ImageCoverStyle.landscape} imageFit={ImageFit.cover} />
-                    <Stack style={{margin: "20px"}}>
+            <Stack horizontal wrap style={{ boxShadow: Depths.depth16 }} maxWidth="1200px">
+                <Image width="100%" height="400px" src={Images.launchAppsHero} coverStyle={ImageCoverStyle.landscape} imageFit={ImageFit.cover} />
+                <Stack style={{margin: "20px"}}>
 
-                        <Text style={{fontFamily: "Segoe UI", fontSize: "30px", fontWeight: "lighter"}}>// Launch</Text>
+                    <Text style={{fontFamily: "Segoe UI", fontSize: "30px", fontWeight: "lighter"}}>// Launch</Text>
 
-                        <Text style={{marginTop: "10px", fontWeight: 500}} variant="xLarge">Learn, develop, and Launch together</Text>
-                        <Text style={{marginTop: "10px"}} variant="mediumPlus">Once a year, our community of Windows App developers join together to release their UWP-related projects. If you’re a developer, new or veteran, then we HIGHLY encourage you to join the server and register your app for the next Launch event!</Text>
-                        <Text style={{marginTop: "10px"}} variant="large">{ user ? "Go to your dashboard to get started" : ""}</Text>
-                    </Stack>
+                    <Text style={{marginTop: "10px", fontWeight: 500}} variant="xLarge">Learn, develop, and Launch together</Text>
+                    <Text style={{marginTop: "10px"}} variant="mediumPlus">Once a year, our community of Windows App developers join together to release their UWP-related projects. If you’re a developer, new or veteran, then we HIGHLY encourage you to join the server and register your app for the next Launch event!</Text>
+                    <Text style={{marginTop: "10px"}} variant="large">{ user ? "Go to your dashboard to get started" : ""}</Text>
                 </Stack>
+            </Stack>
 
-                {projects ? <Text variant="xLarge">Launch 2020 Participants</Text> : <></>}
+            {state.projects && state.projects.length ? <Text variant="xLarge">Launch 2020 Participants</Text> : <></>}
             <Stack horizontal wrap horizontalAlign="center" tokens={{childrenGap: 25}}>
                 {/* Todo: Add launch 2019 summary */}
-                {projects ? projects.map(project => <ProjectCard project={project} />) : <></>}
+                {state.projects && state.projects.length && state.projects.map((project, i) => <ProjectCard key={i} project={project} />)}
+                {!state.projects && state.isLoading && <Spinner label="Checking for Launch 2020 Participants" />}
+                {state.error && (
+                    <Stack horizontalAlign="center">
+                        <FontIcon iconName="sad" style={{ fontSize: 55 }}></FontIcon>
+                        <Text variant="xLarge">An error occured getting launch participants</Text>
+                    </Stack>
+                )}
             </Stack>
+
+            {state.projects && state.isLoading && (
+                <ProgressIndicator />
+            )}
         </Stack>
     );
 };

--- a/src/views/Projects.tsx
+++ b/src/views/Projects.tsx
@@ -1,34 +1,45 @@
 import * as React from "react";
-import { Stack, Text, FontIcon } from "office-ui-fabric-react";
-import { GetAllProjects, IProject } from "../common/services/projects";
+import { Stack, Text, FontIcon, Spinner, ProgressIndicator } from "office-ui-fabric-react";
+import { useProjects } from "../common/services/projects";
 import { ProjectCard } from "../components/ProjectCard";
 
 export const Projects: React.StatelessComponent = () => {
-  const [projects, setProjects] = React.useState<IProject[]>();
-
-  async function PopulateProjects() {
-    const projectsApi = await GetAllProjects();
-    setProjects(projectsApi);
-  }
-
+  const [state, getProjects] = useProjects();
 
   React.useEffect(() => {
-    PopulateProjects();
+    getProjects();
   }, []);
 
   return (
     /* Todo: Add a header with brief explanation of the below */
-    <Stack horizontalAlign="center" horizontal wrap tokens={{ childrenGap: 10 }}>
-      {projects && projects.length > 0 ? projects.map(project => {
-        return (
-          <ProjectCard project={project}></ProjectCard>
-        )
-      }) :
-        <Stack horizontalAlign="center" style={{ marginTop: "25vh" }}>
-          <FontIcon iconName="sad" style={{ fontSize: 55 }}></FontIcon>
-          <Text variant="xLarge">No projects, yet</Text>
-        </Stack>
-      }
-    </Stack>
+    <>
+      <Stack horizontalAlign="center" horizontal wrap tokens={{ childrenGap: 10 }}>
+        {!state.projects && state.isLoading &&
+          <Stack horizontalAlign="center" style={{ marginTop: "25vh" }}>
+            <Spinner label="Loading Projects..." />
+          </Stack>
+        }
+        {state.error && (
+          <Stack horizontalAlign="center" style={{ marginTop: "25vh" }}>
+            <FontIcon iconName="sad" style={{ fontSize: 55 }}></FontIcon>
+            <Text variant="xLarge">An error occured getting projects</Text>
+          </Stack>      
+        )}
+        {state.projects && (
+          state.projects.length > 0 ? state.projects.map((project, i) => (
+            <ProjectCard key={i} project={project}></ProjectCard>
+          )) : (
+            <Stack horizontalAlign="center" style={{ marginTop: "25vh" }}>
+              <FontIcon iconName="sad" style={{ fontSize: 55 }}></FontIcon>
+              <Text variant="xLarge">No projects, yet</Text>
+            </Stack>
+          )
+        )}
+      </Stack>
+      
+      {state.projects && state.isLoading && (
+        <ProgressIndicator />
+      )}
+    </>
   );
 };


### PR DESCRIPTION
This is implemented as a hook shared between the Launch page and the Projects page

This also implements rudimentary caching to avoid the janky flow of `page loads with items -> loading starts, removing items -> items re rendered`