### PR TITLE
Wrong launch year

### DIFF
--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -111,7 +111,7 @@ export const Home: React.StatelessComponent = () => {
                 <Stack horizontal verticalAlign="center" horizontalAlign="center" tokens={{ childrenGap: 7 }}>
                   <Stack style={{ margin: "10px" }} tokens={{ childrenGap: 10 }}>
                     <Text>As a community of talented developers, each year we Launch our projects together in an annual event known as <code>Launch</code></Text>
-                    <Link href={Links.launch2019Medium} target="_blank">Read about Launch 2020</Link>
+                    <Link href={Links.launch2019Medium} target="_blank">Read about Launch 2019</Link>
                   </Stack>
                   <FontAwesomeIcon style={FaIconStyle} icon={["fab", "medium"]} />
                 </Stack>


### PR DESCRIPTION
We have already a link for launch 2020, the one about the annual event still has 2020 texture despite it refers to 2019.